### PR TITLE
Add Windows support to binary buildpack

### DIFF
--- a/bin/compile.bat
+++ b/bin/compile.bat
@@ -1,0 +1,2 @@
+@echo off
+exit /b 0

--- a/bin/detect.bat
+++ b/bin/detect.bat
@@ -1,0 +1,2 @@
+@echo off
+exit /b 1

--- a/bin/release.bat
+++ b/bin/release.bat
@@ -1,0 +1,10 @@
+@echo off
+
+set build_dir=%1
+:: output valid yaml containing the start command
+
+echo ---
+echo default_process_types:
+echo   web: cmd.exe /c exit 1
+
+exit /b 0

--- a/cf_spec/fixtures/windows_app/loop.bat
+++ b/cf_spec/fixtures/windows_app/loop.bat
@@ -1,0 +1,5 @@
+:loop
+
+echo %*
+
+goto loop

--- a/cf_spec/fixtures/windows_app/manifest.yml
+++ b/cf_spec/fixtures/windows_app/manifest.yml
@@ -1,0 +1,3 @@
+---
+health-check-type: none
+command: ./loop.bat Hello, world!

--- a/cf_spec/integration/deploy_a_binary_windows_app_spec.rb
+++ b/cf_spec/integration/deploy_a_binary_windows_app_spec.rb
@@ -1,0 +1,39 @@
+require 'spec_helper'
+
+describe 'CF Binary Buildpack' do
+  after do
+    Machete::CF::DeleteApp.new.execute(app)
+  end
+
+  describe 'deploying a Windows batch script' do
+    let(:app_name) { 'windows_app' }
+
+    context 'when specifying a buildpack' do
+      let(:app) { Machete.deploy_app(app_name, buildpack: 'binary-test-buildpack', stack: 'windows2012R2') }
+
+      it 'deploys successfully' do
+        expect(app).to be_running
+
+        expect(app).to have_logged("Hello, world!")
+      end
+    end
+
+    context 'without specifying a buildpack' do
+      let(:app) { Machete.deploy_app(app_name, stack: 'windows2012R2') }
+
+      it 'fails to stage' do
+        expect(app).not_to be_running
+
+        if diego_enabled?(app_name)
+          expect(app).to have_logged('None of the buildpacks detected a compatible application')
+        else
+          expect(app).to have_logged('An app was not successfully detected by any available buildpack')
+        end
+      end
+    end
+  end
+
+  def diego_enabled?(app_name)
+    `cf has-diego-enabled #{app_name}`.chomp == 'true'
+  end
+end


### PR DESCRIPTION
This PR adds Windows support to the binary buildpack by introducing Windows specific detect, compile and release scripts.

The Windows app lifecycle looks for .BAT files to determine stack compatibility (more on that later!) By introducing these .BAT scripts, the binary-buildpack will run on Windows, with a new (not yet released) lifecycle.

Note that the tests require a Windows cell to run and likely won't work with PCF Dev. I'm not sure how y'all will want to switch these on and off in your environments.