### PR TITLE
Print a warning if web.config is detected

### DIFF
--- a/bin/release.bat
+++ b/bin/release.bat
@@ -1,10 +1,2 @@
 @echo off
-
-set build_dir=%1
-:: output valid yaml containing the start command
-
-echo ---
-echo default_process_types:
-echo   web: cmd.exe /c exit 1
-
-exit /b 0
+powershell.exe %~dp0\release.ps1 %1

--- a/bin/release.ps1
+++ b/bin/release.ps1
@@ -1,0 +1,15 @@
+Param(
+  [Parameter(Mandatory=$True,Position=1)]
+    [string]$BuildDir
+)
+
+if ((Test-Path("$BuildDir\web.config"))) {
+  $message = "Warning: We detected a Web.config in your app. This probably means that you want to use the hwc-buildpack. If you really want to use the binary-buildpack, you must specify a start command."
+} else {
+  $message = "Error: no start command specified during staging or launch"
+}
+
+echo ---
+echo default_process_types:
+echo "  web: >"
+echo "    powershell.exe -Command `"[Console]::Error.WriteLine('$message'); Exit(1)`""

--- a/cf_spec/integration/deploy_a_binary_windows_app_spec.rb
+++ b/cf_spec/integration/deploy_a_binary_windows_app_spec.rb
@@ -35,6 +35,16 @@ describe 'CF Binary Buildpack' do
         end
       end
     end
+
+    context 'without a command or Procfile' do
+      let(:app) { Machete.deploy_app(app_name, buildpack: 'binary-test-buildpack', stack: 'windows2012R2', start_command: 'null') }
+
+      it 'logs an error message' do
+        skip_if_no_windows_stack
+
+        expect(app).to have_logged("Error: no start command specified during staging or launch")
+      end
+    end
   end
 
   def diego_enabled?(app_name)

--- a/cf_spec/integration/deploy_an_hwc_app_spec.rb
+++ b/cf_spec/integration/deploy_an_hwc_app_spec.rb
@@ -1,0 +1,31 @@
+require 'spec_helper'
+
+describe 'CF Binary Buildpack' do
+  after do
+    Machete::CF::DeleteApp.new.execute(app)
+  end
+
+  describe 'deploying a Windows HWC app' do
+    let(:app_name) { 'hwc_app' }
+
+    context 'without a command or Procfile' do
+      let(:app) { Machete.deploy_app(app_name, buildpack: 'binary-test-buildpack', stack: 'windows2012R2', start_command: 'null') }
+
+      it 'logs a warning message' do
+        skip_if_no_windows_stack
+
+        expect(app).to have_logged("Warning: We detected a Web.config in your app. This probably means that you want to use the hwc-buildpack. If you really want to use the binary-buildpack, you must specify a start command.")
+      end
+    end
+  end
+
+  def skip_if_no_windows_stack
+    return if has_windows_stack?
+
+    skip 'cf installation does not have a Windows stack'
+  end
+
+  def has_windows_stack?
+    `cf stacks`.include? 'windows2012R2'
+  end
+end


### PR DESCRIPTION
Thanks for contributing to the buildpack. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:
This PR prints an error in the app logs if it has a Web.config and was pushed without a `command` or `Procfile`

* An explanation of the use cases your change solves
When there's a Web.config included in the source code, the developer probably wants to launch their app with Hosted Web Core. That likely means they want to use the hwc-buildpack. However, there are legititate cases to use the binary_buildpack with Web.config, so we only print this message when there is no start command or Procfile.

* [X] I have viewed signed and have submitted the Contributor License Agreement

* [X] I have made this pull request to the `develop` branch

* [X] I have added an integration test
