### PR TITLE
Run release.ps1 with Unrestricted execution policy

### DIFF
--- a/bin/release.bat
+++ b/bin/release.bat
@@ -1,2 +1,2 @@
 @echo off
-powershell.exe %~dp0\release.ps1 %1
+powershell.exe -ExecutionPolicy Unrestricted %~dp0\release.ps1 %1


### PR DESCRIPTION
Thanks for contributing to the buildpack. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:

The default PowerShell execution policy prevents release.ps1 from running. We never noticed this with BOSH deployed cells because on AWS, we change the execution policy.

* An explanation of the use cases your change solves

This allows the binary buildpack to run on MSI deployed Windows cells.

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `develop` branch
