### PR TITLE
Run compile.ps1 with Unrestricted execution policy

### DIFF
--- a/bin/compile.bat
+++ b/bin/compile.bat
@@ -1,2 +1,2 @@
 @echo off
-powershell.exe %~dp0\compile.ps1 %1 %2 %3
+powershell.exe -ExecutionPolicy Unrestricted %~dp0\compile.ps1 %1 %2 %3


### PR DESCRIPTION
Thanks for contributing to the buildpack. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:

The default PowerShell execution policy prevents compile.ps1 from running. We fixed this for release.ps1, but didn't realize compile.ps1 was failing as well.

* An explanation of the use cases your change solves

This allows the binary buildpack to run on hardened stemcells.

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `develop` branch