### PR TITLE
Change buildpack phrasing to use a space instead of a dash

### DIFF
--- a/bin/release.bat
+++ b/bin/release.bat
@@ -1,7 +1,7 @@
 @echo off
 
 if exist %1\web.config (
-    set message=Warning: We detected a Web.config in your app. This probably means that you want to use the hwc-buildpack. If you really want to use the binary-buildpack, you must specify a start command.
+    set message=Warning: We detected a Web.config in your app. This probably means that you want to use the HWC Buildpack (run cf buildpacks for exact buildpack name). If you really want to use the Binary Buildpack, you must specify a start command.
 ) else (
     set message=Error: no start command specified during staging or launch
 )


### PR DESCRIPTION
* A short explanation of the proposed change:
Changing the hwc and binary buildpack references per below:
hwc-buildpack -> HWC Buildpack
binary-buildpack -> Binary Buildpack

* An explanation of the use cases your change solves:
Avoid confusion due to default naming convention of buildpacks (using an underscore '_').

* [X] I have made this pull request to the `develop` branch

Closes #25