### PR TITLE
Remove references to windows2016 stack

### DIFF
--- a/src/binary/integration/integration_suite_test.go
+++ b/src/binary/integration/integration_suite_test.go
@@ -79,7 +79,7 @@ func PushAppAndConfirm(app *cutlass.App) {
 }
 
 func SkipIfNotWindows() {
-	if os.Getenv("SKIP_WINDOWS_TESTS") != "" || !canRunForOneOfStacks("windows2012R2", "windows2016", "windows") {
+	if os.Getenv("SKIP_WINDOWS_TESTS") != "" || !canRunForOneOfStacks("windows2012R2", "windows") {
 		Skip("Skipping Windows tests")
 	}
 }


### PR DESCRIPTION
Thanks for contributing to the buildpack. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change: 

The `windows2016` stack is no longer supported. See [cloudfoundry docs](https://docs.cloudfoundry.org/devguide/deploy-apps/windows-stacks.html):

> "If you push your Cloud Foundry app to a Windows stack, you must use windows. The `windows2016` stack is not supported on Cloud Foundry."

* An explanation of the use cases your change solves:

`windows2016` and `windows` stacks are equivalent, but `windows2016` was deprecated and is now being removed to avoid confusion.

* [X] I have viewed signed and have submitted the Contributor License Agreement

* [X] I have made this pull request to the `develop` branch

* [X] I have added an integration test
The change modifies the integration tests.

