### PR TITLE
Integration suite should support --platform flag

### DIFF
--- a/src/binary/integration/integration_suite_test.go
+++ b/src/binary/integration/integration_suite_test.go
@@ -18,6 +18,7 @@ var bpDir string
 var buildpackVersion string
 var packagedBuildpack cutlass.VersionedBuildpackPackage
 var token string
+var platform string
 
 var _ = func() bool {
 	testing.Init()
@@ -30,6 +31,7 @@ func init() {
 	flag.StringVar(&cutlass.DefaultMemory, "memory", "128M", "default memory for pushed apps")
 	flag.StringVar(&cutlass.DefaultDisk, "disk", "64M", "default disk for pushed apps")
 	flag.StringVar(&token, "github-token", "", "use the token to make GitHub API requests")
+	flag.StringVar(&platform, "platform", "cf", `switchblade platform to test against ("cf" or "docker")`)
 	flag.Parse()
 }
 


### PR DESCRIPTION
Should fix integration suite errors seen here: https://buildpacks.ci.cf-app.com/teams/main/pipelines/binary-buildpack/jobs/specs-lts-integration-develop/builds/370