### PR TITLE
brats: fix hello world typo error

### DIFF
--- a/fixtures/brats/app
+++ b/fixtures/brats/app
@@ -4,7 +4,7 @@ tmppipe=$(mktemp -u)
 mkfifo "${tmppipe}"
 trap 'rm "${tmppipe}"' EXIT
 
-# On / : Hello, world!
+# On / : Hello World!
 # On other paths: 404
 function handler {
   while read -r line; do
@@ -13,7 +13,7 @@ function handler {
     fi
 
     if [[ "${line:0:10}" = "GET / HTTP" ]]; then
-      echo -e "HTTP/1.1 200 OK\r\nContent-Type: text/html\r\n\r\nHello, world!" > "${tmppipe}"
+      echo -e "HTTP/1.1 200 OK\r\nContent-Type: text/html\r\n\r\nHello World!" > "${tmppipe}"
       return
     fi
   done


### PR DESCRIPTION
This was introduced in https://github.com/cloudfoundry/binary-buildpack/pull/132
