### PR TITLE
remove references to the windows2016 stack

### DIFF
--- a/src/binary/integration/integration_suite_test.go
+++ b/src/binary/integration/integration_suite_test.go
@@ -90,7 +90,7 @@ func PushAppAndConfirm(app *cutlass.App) {
 }
 
 func SkipIfNotWindows() {
-	if os.Getenv("SKIP_WINDOWS_TESTS") != "" || !canRunForOneOfStacks("windows2012R2", "windows2016", "windows") {
+	if os.Getenv("SKIP_WINDOWS_TESTS") != "" || os.Getenv("CF_STACK") != "windows" {
 		Skip("Skipping Windows tests")
 	}
 }


### PR DESCRIPTION
This stack is identical to the windows stack and windows2016 has been unsupported in CF for a long time now. https://docs.cloudfoundry.org/devguide/deploy-apps/windows-stacks.html#-available-stacks

